### PR TITLE
chore: bump proxy version to 1.0.31

### DIFF
--- a/src/main/g8/docker-compose.yml
+++ b/src/main/g8/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.29
+    image: gcr.io/kalix-public/kalix-proxy:1.0.31
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"


### PR DESCRIPTION
References https://github.com/lightbend/kalix-proxy/issues/1792