### PR TITLE
fix: CPU arch detection for docker build

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,7 +8,8 @@ dockerUsername := sys.props.get("docker.username")
 dockerRepository := sys.props.get("docker.registry")
 dockerUpdateLatest := true
 dockerBuildCommand := {
-  if (sys.props("os.arch") != "amd64") {
+  val arch = sys.props("os.arch")
+  if (arch != "amd64" && !arch.contains("x86")) {
     // use buildx with platform to build supported amd64 images on other CPU architectures
     // this may require that you have first run 'docker buildx create' to set docker buildx up
     dockerExecCommand.value ++ Seq("buildx", "build", "--platform=linux/amd64", "--load") ++ dockerBuildOptions.value :+ "."


### PR DESCRIPTION
MacOS intel CPU (sometimes?) reports arch as x86_64 and not amd64 so check for both and cross build only if neither matches.